### PR TITLE
Remove react-scripts from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json /app/package.json
 
 RUN npm install
-# RUN npm install react-scripts@5.0.1 -g
 
 # start app
 CMD ["npm", "start"]


### PR DESCRIPTION
We no longer need this in the Dockerfile as it is installed during the build phase.