### PR TITLE
Update routing for project components page

### DIFF
--- a/cypress/integration/general/test.spec.js
+++ b/cypress/integration/general/test.spec.js
@@ -145,7 +145,7 @@ describe("breadcrumbs show correctly on projects details page", () => {
 
 describe("breadcrumbs show correctly on projects system components page", () => {
   it("does display on project system components page", () => {
-    cy.visit(Cypress.env("BASE_URL") + "/projects/1/system-components");
+    cy.visit(Cypress.env("BASE_URL") + "/projects/1/components");
     cy.get("header").should("exist");
     cy.get(".usa-breadcrumb").should("exist").contains("Home");
     cy.get(".usa-breadcrumb").contains("projects");

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -18,8 +18,7 @@ import ProjectSetup from "./pages/ProjectSetup";
 import ProjectSetupConfirmation from "./pages/ProjectSetupConfirmation";
 import ProjectSystemSecurityPlan from "./pages/ProjectSystemSecurityPlan";
 import ProjectSetupSelectComponents from "./pages/ProjectSetupSelectComponents";
-import ProjectSystemComponents from "./pages/ProjectSystemComponents";
-
+import ProjectComponents from "./pages/ProjectComponents";
 
 export const MAIN_ROUTES = {
   HOME: "/",
@@ -45,10 +44,7 @@ export const AppRoutes = () => (
         <Route path=":id">
           <Route index element={<Project />} />
           <Route path="settings" element={<ProjectSettings />} />
-          <Route
-            path="system-components"
-            element={<ProjectSystemComponents />}
-          />
+          <Route path="components" element={<ProjectComponents />} />
           <Route path="controls">
             <Route index element={<Controls />} />
             <Route path=":controlId" element={<Control />} />

--- a/src/organisms/ComponentsList.jsx
+++ b/src/organisms/ComponentsList.jsx
@@ -3,7 +3,7 @@ import { ComponentListItem } from "../molecules/ComponentListItem";
 
 const ComponentsList = ({ componentList }) => {
   const params = useLocation();
-  const manageComponentsUrl = params.pathname + "/system-components";
+  const manageComponentsUrl = params.pathname + "/components";
   return (
     <>
       {componentList.map((component, i) => (

--- a/src/pages/ProjectComponents.jsx
+++ b/src/pages/ProjectComponents.jsx
@@ -8,11 +8,11 @@ import RequestService from "../services/RequestService";
 import ErrorMessage from "../molecules/ErrorMessage";
 import GlobalState from "../GlobalState";
 import LoadingIndicator from "../atoms/LoadingIndicator";
-import ProjectSystemComponentsTemplate from "../templates/ProjectSystemComponentsTemplate";
+import ProjectComponentsTemplate from "../templates/ProjectComponentsTemplate";
 
 const ERROR_MESSAGE = "Error loading system components";
 
-const ProjectSystemComponents = () => {
+const ProjectComponents = () => {
   const { id } = useParams();
 
   const [state, setState] = useContext(GlobalState);
@@ -53,7 +53,7 @@ const ProjectSystemComponents = () => {
     return <ErrorMessage message={ERROR_MESSAGE} />;
   }
   return (
-    <ProjectSystemComponentsTemplate
+    <ProjectComponentsTemplate
       project={state.project}
       componentList={componentList}
       totalItemCount={totalItemCount}
@@ -62,4 +62,4 @@ const ProjectSystemComponents = () => {
   );
 };
 
-export default ProjectSystemComponents;
+export default ProjectComponents;

--- a/src/templates/ProjectComponentsTemplate.jsx
+++ b/src/templates/ProjectComponentsTemplate.jsx
@@ -3,7 +3,7 @@ import ProjectHeader from "../molecules/ProjectHeader";
 import { Link } from "react-router-dom";
 import { MAIN_ROUTES } from "../AppRoutes";
 
-const ProjectSystemComponentsTemplate = ({
+const ProjectComponentsTemplate = ({
   project,
   componentList,
   totalItemCount,
@@ -37,4 +37,4 @@ const ProjectSystemComponentsTemplate = ({
   );
 };
 
-export default ProjectSystemComponentsTemplate;
+export default ProjectComponentsTemplate;

--- a/src/templates/ProjectTemplate.jsx
+++ b/src/templates/ProjectTemplate.jsx
@@ -6,7 +6,7 @@ export function ProjectTemplate({ project }) {
   const { id, acronym, impact_level, title } = project;
   const sspUrl = "/projects/" + id + "/system-security-plan";
   const params = useLocation();
-  const manageComponentsUrl = params.pathname + "/system-components";
+  const manageComponentsUrl = params.pathname + "/components";
   return (
     <div>
       <ProjectHeader


### PR DESCRIPTION
*What does this PR do?*
Updates the route for accessing a project's components. We were doing this with two different urls in the app, so this updates to use the same one.

*Jira ticket number?*
N/A

*Changes*

- Updated routing for a project's components page from `/projects/{id}/system-components` to `/projects/{id}/components`
- Updated component names from ProjectSystemComponent to ProjectComponent
- Updated link for the `Manage System Components` button on the project homepage to match the updated route

*Testing*
- test for regression on the urls described in the changes and links to those pages via the `/projects` page and from an individual project homepage
