### PR TITLE
Feature/1217 token expiry

### DIFF
--- a/src/organisms/Header.test.js
+++ b/src/organisms/Header.test.js
@@ -93,9 +93,11 @@ describe("user info in header", () => {
 
   test("clicking username will log out the user", () => {
     const username = "admin";
+    const token = "1234567890token";
     const clearSessionSpy = jest.spyOn(window.sessionStorage, "clear");
     const windowLocationSpy = jest.spyOn(window.location, "assign");
     window.sessionStorage.setItem("Username", username);
+    window.sessionStorage.setItem("Token", token);
 
     render(
       <MemoryRouter>
@@ -111,6 +113,7 @@ describe("user info in header", () => {
 
     // username no longer exists in session storage
     expect(window.sessionStorage.getItem("Username")).toEqual(null);
+    expect(window.sessionStorage.getItem("Token")).toEqual(null);
 
     // user is redirected to login page
     expect(windowLocationSpy).toHaveBeenCalledTimes(1);

--- a/src/services/RequestService.js
+++ b/src/services/RequestService.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { config as configUrl } from "../config";
+import { MAIN_ROUTES } from "../AppRoutes";
 
 const config = {
   headers: {
@@ -27,14 +28,24 @@ export function isAuthPost(url) {
   }
 }
 
+// Checks if error is a 401 (Unauthorized)
+// if so, will clear session storage and redirect user to login
+export function handleExpiredToken() {
+  sessionStorage.clear();
+  window.location.assign(MAIN_ROUTES.LOGIN);
+}
+
 const RequestService = {
   get: async (url, callback, failureCallback) => {
     axios
       .get(url, authConfig)
       .then((response) => {
-        callback(response);
+        callback && callback(response);
       })
-      .catch((err) => failureCallback && failureCallback(err));
+      .catch((err) => {
+        err.response.status === 401 && handleExpiredToken();
+        failureCallback && failureCallback(err);
+      });
   },
   post: async (url, body, callback, failureCallback) => {
     let postConfig = authConfig;
@@ -48,17 +59,23 @@ const RequestService = {
     axios
       .post(url, body, postConfig)
       .then((response) => {
-        callback(response);
+        callback && callback(response);
       })
-      .catch((err) => failureCallback && failureCallback(err));
+      .catch((err) => {
+        err.response.status === 401 && handleExpiredToken();
+        failureCallback && failureCallback(err);
+      });
   },
   delete: async (url, callback, failureCallback) => {
     axios
       .delete(url, authConfig)
       .then((response) => {
-        callback(response);
+        callback && callback(response);
       })
-      .catch((err) => failureCallback && failureCallback(err));
+      .catch((err) => {
+        err.response.status === 401 && handleExpiredToken();
+        failureCallback && failureCallback(err);
+      });
   },
 };
 

--- a/src/services/RequestService.test.js
+++ b/src/services/RequestService.test.js
@@ -7,43 +7,75 @@ describe("<RequestService />", () => {
   const data = { response: true };
   let mock = new MockAdapter(axios);
 
-  it("gets", () => {
+  it("gets", (done) => {
     mock.onGet("fake.url").reply(200, data);
-    return RequestService.get("fake.url", (response) => {
-      expect(response.status).toBe(200);
-      expect(response.data).toStrictEqual(data);
+    RequestService.get("fake.url", (response) => {
+      try {
+        expect(response.status).toBe(200);
+        expect(response.data).toStrictEqual(data);
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
-  it("gets and fails", () => {
+  it("gets and fails", (done) => {
     mock.onGet("fake.url").reply(500, data);
-    return RequestService.get("fake.url", null, (err) => {
-      expect(err.response.status).toBe(500);
+    RequestService.get("fake.url", null, (err) => {
+      try {
+        expect(err.response.status).toBe(500);
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
-  it("posts", () => {
+
+  it("posts", (done) => {
     mock.onPost("fake.url").reply(200, data);
-    return RequestService.post("fake.url", {}, (response) => {
-      expect(response.status).toBe(200);
-      expect(response.data).toStrictEqual(data);
+    RequestService.post("fake.url", {}, (response) => {
+      try {
+        expect(response.status).toBe(200);
+        expect(response.data).toStrictEqual(data);
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
-  it("posts and fails", () => {
+  it("posts and fails", (done) => {
     mock.onPost("fake.url").reply(500, data);
-    return RequestService.post("fake.url", {}, null, (err) => {
-      expect(err.response.status).toBe(500);
+    RequestService.post("fake.url", {}, null, (err) => {
+      try {
+        expect(err.response.status).toBe(500);
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
-  it("deletes", () => {
+
+  it("deletes", (done) => {
     mock.onDelete("fake.url").reply(200, data);
-    return RequestService.delete("fake.url", (response) => {
-      expect(response.status).toBe(200);
-      expect(response.data).toStrictEqual(data);
+    RequestService.delete("fake.url", (response) => {
+      try {
+        expect(response.status).toBe(200);
+        expect(response.data).toStrictEqual(data);
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
-  it("deletes and fails", () => {
+  it("deletes and fails", (done) => {
     mock.onDelete("fake.url").reply(500, data);
-    return RequestService.delete("fake.url", null, (err) => {
-      expect(err.response.status).toBe(500);
+    RequestService.delete("fake.url", null, (err) => {
+      try {
+        expect(err.response.status).toBe(500);
+        done();
+      } catch (error) {
+        done(error);
+      }
     });
   });
 });

--- a/src/services/RequestService.test.js
+++ b/src/services/RequestService.test.js
@@ -1,9 +1,6 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import RequestService, {
-  handleExpiredToken,
-  isAuthPost,
-} from "./RequestService";
+import RequestService, { isAuthPost } from "./RequestService";
 import { config } from "../config";
 
 describe("<RequestService />", () => {
@@ -112,77 +109,5 @@ describe("isAuthPost function", () => {
     const notUsersUrlAndNotLoginUrl = `${config.backendUrl}/projects/`;
     const isAuthPostReturn = isAuthPost(notUsersUrlAndNotLoginUrl);
     expect(isAuthPostReturn).toBeFalsy();
-  });
-});
-
-describe("handleExpiredToken function", () => {
-  const oldWindowLocation = window.location;
-  const sessionStorageMock = (() => {
-    let store = {};
-
-    return {
-      getItem(key) {
-        return store[key] || null;
-      },
-      setItem(key, value) {
-        store[key] = value.toString();
-      },
-      removeItem(key) {
-        delete store[key];
-      },
-      clear() {
-        store = {};
-      },
-    };
-  })();
-
-  Object.defineProperty(window, "sessionStorage", {
-    value: sessionStorageMock,
-  });
-
-  beforeAll(() => {
-    delete window.location;
-    window.location = Object.defineProperties(
-      {},
-      {
-        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
-        assign: {
-          configurable: true,
-          value: jest.fn(),
-        },
-      }
-    );
-  });
-
-  beforeEach(() => {
-    window.sessionStorage.clear();
-    window.location.assign.mockReset();
-    jest.restoreAllMocks();
-  });
-
-  afterAll(() => {
-    window.sessionStorage.clear();
-    window.location = oldWindowLocation;
-    jest.restoreAllMocks();
-  });
-
-  it("clears session storage and returns user to login page", () => {
-    const username = "admin";
-    const token = "1234567890token";
-    const clearSessionSpy = jest.spyOn(window.sessionStorage, "clear");
-    const windowLocationSpy = jest.spyOn(window.location, "assign");
-    window.sessionStorage.setItem("Username", username);
-    window.sessionStorage.setItem("Token", token);
-
-    handleExpiredToken();
-
-    // sessionStorage is cleared removing authentication info
-    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
-    expect(window.sessionStorage.getItem("Username")).toEqual(null);
-    expect(window.sessionStorage.getItem("Token")).toEqual(null);
-
-    // user is redirected to home page
-    expect(windowLocationSpy).toHaveBeenCalledTimes(1);
-    expect(windowLocationSpy).toBeCalledWith("/login");
   });
 });

--- a/src/services/RequestService.test.js
+++ b/src/services/RequestService.test.js
@@ -5,7 +5,19 @@ import { config } from "../config";
 
 describe("<RequestService />", () => {
   const data = { response: true };
-  let mock = new MockAdapter(axios);
+  let mock;
+
+  beforeAll(() => {
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    mock.reset();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
 
   it("gets", (done) => {
     mock.onGet("fake.url").reply(200, data);

--- a/src/services/RequestService.test.js
+++ b/src/services/RequestService.test.js
@@ -1,6 +1,9 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import RequestService, { isAuthPost } from "./RequestService";
+import RequestService, {
+  handleExpiredToken,
+  isAuthPost,
+} from "./RequestService";
 import { config } from "../config";
 
 describe("<RequestService />", () => {
@@ -109,5 +112,77 @@ describe("isAuthPost function", () => {
     const notUsersUrlAndNotLoginUrl = `${config.backendUrl}/projects/`;
     const isAuthPostReturn = isAuthPost(notUsersUrlAndNotLoginUrl);
     expect(isAuthPostReturn).toBeFalsy();
+  });
+});
+
+describe("handleExpiredToken function", () => {
+  const oldWindowLocation = window.location;
+  const sessionStorageMock = (() => {
+    let store = {};
+
+    return {
+      getItem(key) {
+        return store[key] || null;
+      },
+      setItem(key, value) {
+        store[key] = value.toString();
+      },
+      removeItem(key) {
+        delete store[key];
+      },
+      clear() {
+        store = {};
+      },
+    };
+  })();
+
+  Object.defineProperty(window, "sessionStorage", {
+    value: sessionStorageMock,
+  });
+
+  beforeAll(() => {
+    delete window.location;
+    window.location = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        assign: {
+          configurable: true,
+          value: jest.fn(),
+        },
+      }
+    );
+  });
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.location.assign.mockReset();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    window.sessionStorage.clear();
+    window.location = oldWindowLocation;
+    jest.restoreAllMocks();
+  });
+
+  it("clears session storage and returns user to login page", () => {
+    const username = "admin";
+    const token = "1234567890token";
+    const clearSessionSpy = jest.spyOn(window.sessionStorage, "clear");
+    const windowLocationSpy = jest.spyOn(window.location, "assign");
+    window.sessionStorage.setItem("Username", username);
+    window.sessionStorage.setItem("Token", token);
+
+    handleExpiredToken();
+
+    // sessionStorage is cleared removing authentication info
+    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("Username")).toEqual(null);
+    expect(window.sessionStorage.getItem("Token")).toEqual(null);
+
+    // user is redirected to home page
+    expect(windowLocationSpy).toHaveBeenCalledTimes(1);
+    expect(windowLocationSpy).toBeCalledWith("/login");
   });
 });

--- a/src/services/RequestServiceRenders.test.js
+++ b/src/services/RequestServiceRenders.test.js
@@ -1,0 +1,153 @@
+import axios from "axios";
+import { MemoryRouter } from "react-router-dom";
+import { render, waitFor } from "@testing-library/react";
+import {
+  DeleteComponent,
+  GetComponent,
+  PostComponent,
+} from "../testUtils/componentsUsingRequestService";
+
+jest.mock("axios");
+
+describe("RequestService handles 401 request", () => {
+  const oldWindowLocation = window.location;
+  const sessionStorageMock = (() => {
+    let store = {};
+
+    return {
+      getItem(key) {
+        return store[key] || null;
+      },
+      setItem(key, value) {
+        store[key] = value.toString();
+      },
+      removeItem(key) {
+        delete store[key];
+      },
+      clear() {
+        store = {};
+      },
+    };
+  })();
+
+  Object.defineProperty(window, "sessionStorage", {
+    value: sessionStorageMock,
+  });
+
+  beforeAll(() => {
+    delete window.location;
+    window.location = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        assign: {
+          configurable: true,
+          value: jest.fn(),
+        },
+      }
+    );
+  });
+
+  beforeEach(() => {
+    const username = "admin";
+    const token = "1234567890token";
+    window.sessionStorage.setItem("Username", username);
+    window.sessionStorage.setItem("Token", token);
+    window.sessionStorage.clear();
+    window.location.assign.mockReset();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    window.sessionStorage.clear();
+    window.location = oldWindowLocation;
+    jest.restoreAllMocks();
+  });
+
+  it("delete attempt clears session storage and redirects user to login page", async () => {
+    const errorResponse = {
+      response: {
+        message: "Request failed with status code 401",
+        code: "ERR_BAD_REQUEST",
+        status: 401,
+      },
+    };
+    axios.delete.mockImplementation(() => Promise.reject(errorResponse));
+
+    const clearSessionSpy = jest.spyOn(window.sessionStorage, "clear");
+    const windowLocationSpy = jest.spyOn(window.location, "assign");
+
+    render(
+      <MemoryRouter>
+        <DeleteComponent />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      // user is redirected to home page
+      expect(windowLocationSpy).toBeCalledWith("/login");
+    });
+    // sessionStorage is cleared removing authentication info
+    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("Username")).toEqual(null);
+    expect(window.sessionStorage.getItem("Token")).toEqual(null);
+  });
+
+  it("get attempt clears session storage and redirects user to login page", async () => {
+    const errorResponse = {
+      response: {
+        message: "Request failed with status code 401",
+        code: "ERR_BAD_REQUEST",
+        status: 401,
+      },
+    };
+    axios.get.mockImplementation(() => Promise.reject(errorResponse));
+
+    const clearSessionSpy = jest.spyOn(window.sessionStorage, "clear");
+    const windowLocationSpy = jest.spyOn(window.location, "assign");
+
+    render(
+      <MemoryRouter>
+        <GetComponent />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      // user is redirected to home page
+      expect(windowLocationSpy).toBeCalledWith("/login");
+    });
+    // sessionStorage is cleared removing authentication info
+    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("Username")).toEqual(null);
+    expect(window.sessionStorage.getItem("Token")).toEqual(null);
+  });
+
+  it("post attempt clears session storage and redirects user to login page", async () => {
+    const errorResponse = {
+      response: {
+        message: "Request failed with status code 401",
+        code: "ERR_BAD_REQUEST",
+        status: 401,
+      },
+    };
+    axios.post.mockImplementation(() => Promise.reject(errorResponse));
+
+    const clearSessionSpy = jest.spyOn(window.sessionStorage, "clear");
+    const windowLocationSpy = jest.spyOn(window.location, "assign");
+
+    render(
+      <MemoryRouter>
+        <PostComponent />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      // user is redirected to home page
+      expect(windowLocationSpy).toBeCalledWith("/login");
+    });
+    // sessionStorage is cleared removing authentication info
+    expect(clearSessionSpy).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("Username")).toEqual(null);
+    expect(window.sessionStorage.getItem("Token")).toEqual(null);
+  });
+});

--- a/src/testUtils/componentsUsingRequestService.jsx
+++ b/src/testUtils/componentsUsingRequestService.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useEffect, useState } from "react";
+import RequestService from "../services/RequestService";
+import ErrorMessage from "../molecules/ErrorMessage";
+
+export function DeleteComponent() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    RequestService.delete(`fake-url.com`, (response) => {
+      setData(response.data);
+    });
+  }, []);
+
+  if (data) {
+    return <div>Test Component data: {data}</div>;
+  }
+  return <ErrorMessage />;
+}
+
+export function GetComponent() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    RequestService.get(`fake-url.com`, (response) => {
+      setData(response.data);
+    });
+  }, []);
+
+  if (data) {
+    return <div>Test Component data: {data}</div>;
+  }
+  return <ErrorMessage />;
+}
+
+export function PostComponent() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    RequestService.post(`fake-url.com`, (response) => {
+      setData(response.data);
+    });
+  }, []);
+
+  if (data) {
+    return <div>Test Component data: {data}</div>;
+  }
+  return <ErrorMessage />;
+}


### PR DESCRIPTION
*What does this PR do?*
Adds handling for expired tokens when making api calls instead of just showing the user an Error.

*Jira ticket number?*
[ISPGBSS-1217](https://jiraent.cms.gov/browse/ISPGBSS-1217)

*Changes*

- added `handleExpiredToken` function to be called whenever the status of a call is 401
  - this function will clear session storage of expired tokens and also redirect user to login page
-  added a testUtils folder to house test components that use RequestService in order to test the implementation of the `handleExpiredToken` function. 
   - These tests live in a different test file `RequestServiceRenders.test.js` since we need to use jest mocks, instead of mockadapter, to correctly handle the rejected response. Both can't live in the same file since they're mocking the same axios function.
- updated existing request service tests because they were broken :( We needed to handle the asynchronicity and this was accomplished by incorporating `done` functions and `try/catch` blocks
- updated the Header.test.jsx file to also test for the token in addition to username, just making the test more thorough

