### PR TITLE
Feature/1179 control page fixes

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -302,7 +302,7 @@ nav.usa-breadcrumb {
   .usa-accordion__content {
     white-space: break-spaces;
   }
-  .bottom-setion {
+  .bottom-section {
     display: flex;
     justify-content: space-between;
     button {

--- a/src/App.scss
+++ b/src/App.scss
@@ -26,6 +26,7 @@ $card-collection-three-per-row-width: 901px;
   .Toastify__toast {
     border-radius: 0;
     padding: 0 !important;
+    min-height: 0;
     .Toastify__toast-body {
       padding: 0;
     }

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -1,9 +1,4 @@
 export const getControlData = (component = {}, controlId) => {
-  const getControlResponsiblity = () => {
-    let r = controls[controlId].responsibility;
-    return r === "Hybrid" ? "some" : r === "Inherited" ? "none" : "some";
-  };
-
   const getControlText = () => {
     if (Object.prototype.hasOwnProperty.call(controls, controlId)) {
       return controls[controlId].narrative;
@@ -30,7 +25,7 @@ export const getControlData = (component = {}, controlId) => {
     guidance: getCatalogControlData("guidance"),
     implementationStandards: getCatalogControlData("implementation"),
     narrative: controlId ? getControlText() : "",
-    responsibility: getControlResponsiblity(),
+    responsibility: getCatalogControlData("responsibility"),
   };
 
   return controlData;

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -33,7 +33,7 @@ export const getControlData = (component = {}, controlId) => {
 
 export const formatCatalogTitle = (catalogTitle) => {
   let titleArray = catalogTitle.split("_");
-  if (titleArray.length == 5) {
+  if (titleArray.length === 5) {
     let formattedImpactLevel =
       titleArray[4][0].toUpperCase() + titleArray[4].substring(1).toLowerCase();
     return (

--- a/src/atoms/ResponsibilityBox.jsx
+++ b/src/atoms/ResponsibilityBox.jsx
@@ -1,7 +1,10 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
 
-export default function ResponsibilityBox({ responsibility }) {
+export default function ResponsibilityBox({ responsibilityForControl }) {
+  // sets default responsibility as Allocated
+  let responsibility = responsibilityForControl || "Allocated";
+
   const RESPONSIBILITY_MAP = {
     Inherited: {
       title:
@@ -57,6 +60,10 @@ export default function ResponsibilityBox({ responsibility }) {
 }
 
 ResponsibilityBox.propTypes = {
-  responsibility: PropTypes.oneOf(["Inherited", "Hybrid", "Allocated"])
-    .isRequired,
+  responsibilityForControl: PropTypes.oneOf([
+    "Inherited",
+    "Hybrid",
+    "Allocated",
+    null,
+  ]),
 };

--- a/src/atoms/ResponsibilityBox.test.jsx
+++ b/src/atoms/ResponsibilityBox.test.jsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 import ResponsibilityBox from "./ResponsibilityBox";
 
 test("renders title and class for responsibility of Inherited", () => {
-  render(<ResponsibilityBox responsibility="Inherited" />);
+  render(<ResponsibilityBox responsibilityForControl="Inherited" />);
 
   const expectedTitle =
     "Fully Inherited Control: No system responsibility for addressing this control";
@@ -15,7 +15,7 @@ test("renders title and class for responsibility of Inherited", () => {
 });
 
 test("renders title and class for responsibility of Hybrid", () => {
-  render(<ResponsibilityBox responsibility="Hybrid" />);
+  render(<ResponsibilityBox responsibilityForControl="Hybrid" />);
 
   const expectedTitle =
     "Shared / Hybrid Control: System is partially responsible for addressing this control";
@@ -27,7 +27,43 @@ test("renders title and class for responsibility of Hybrid", () => {
 });
 
 test("renders title and class for responsibility of Allocated", () => {
-  render(<ResponsibilityBox responsibility="Allocated" />);
+  render(<ResponsibilityBox responsibilityForControl="Allocated" />);
+
+  const expectedTitle =
+    "Allocated Control: System is fully responsible for addressing this control";
+  const expectedClass = "responsibility-box--yellow";
+
+  const responsibilityBox = screen.getByTestId("responsibility_box");
+  expect(responsibilityBox).toHaveTextContent(expectedTitle);
+  expect(responsibilityBox).toHaveClass(expectedClass);
+});
+
+test("assigns Allocated responsibility as default when NO value passed in", () => {
+  render(<ResponsibilityBox />);
+
+  const expectedTitle =
+    "Allocated Control: System is fully responsible for addressing this control";
+  const expectedClass = "responsibility-box--yellow";
+
+  const responsibilityBox = screen.getByTestId("responsibility_box");
+  expect(responsibilityBox).toHaveTextContent(expectedTitle);
+  expect(responsibilityBox).toHaveClass(expectedClass);
+});
+
+test("assigns Allocated responsibility as default when NULL value passed in", () => {
+  render(<ResponsibilityBox responsibilityForControl={null} />);
+
+  const expectedTitle =
+    "Allocated Control: System is fully responsible for addressing this control";
+  const expectedClass = "responsibility-box--yellow";
+
+  const responsibilityBox = screen.getByTestId("responsibility_box");
+  expect(responsibilityBox).toHaveTextContent(expectedTitle);
+  expect(responsibilityBox).toHaveClass(expectedClass);
+});
+
+test("assigns Allocated responsibility as default when UNDEFINED value passed in", () => {
+  render(<ResponsibilityBox responsibilityForControl={undefined} />);
 
   const expectedTitle =
     "Allocated Control: System is fully responsible for addressing this control";

--- a/src/pages/Component.jsx
+++ b/src/pages/Component.jsx
@@ -82,7 +82,7 @@ const Component = () => {
     return (
       <ComponentTemplate
         component={state.component}
-        controlText={selectedControl}
+        selectedControl={selectedControl}
         catalogData={getControl}
         handleProjectUpdate={handleProjectUpdate}
       />

--- a/src/pages/Control.jsx
+++ b/src/pages/Control.jsx
@@ -40,8 +40,8 @@ export default function Control() {
 
   function postControlUpdate(postVariables) {
     const nextPageId = pageData.catalog_data.next_id;
-    RequestService.post(
-      `${config.backendUrl}/projects/${id}/controls/${controlId}/`,
+    RequestService.patch(
+      `${config.backendUrl}/projects/${id}/controls/${nextPageId}/`,
       JSON.stringify(postVariables),
       (response) => {
         toast(AlertToast("success", `Control ${controlId} has been saved.`));

--- a/src/pages/Control.jsx
+++ b/src/pages/Control.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import AlertToast from "../atoms/AlertToast";
 
 import { config } from "../config";
 import RequestService from "../services/RequestService";
@@ -37,13 +39,17 @@ export default function Control() {
   }, [controlId, id, setState]);
 
   function postControlUpdate(postVariables) {
-    let nextPageId = pageData.catalog_data.next_id;
+    const nextPageId = pageData.catalog_data.next_id;
     RequestService.post(
       `${config.backendUrl}/projects/${id}/controls/${controlId}/`,
       JSON.stringify(postVariables),
       (response) => {
+        toast(AlertToast("success", `Control ${controlId} has been saved.`));
         const nextLink = `/projects/${id}/controls/${nextPageId}`;
         navigate(nextLink);
+      },
+      (err) => {
+        toast(AlertToast("error", `Something went wrong, try again.`));
       }
     );
   }

--- a/src/pages/Control.jsx
+++ b/src/pages/Control.jsx
@@ -17,7 +17,7 @@ const ERROR_MESSAGE = "Error loading project control";
 export default function Control() {
   const navigate = useNavigate();
   const { id, controlId } = useParams();
-  const [state, setState] = useContext(GlobalState);
+  const [, setState] = useContext(GlobalState);
   const [pageData, setPageData] = useState();
   const [hasError, setHasError] = useState(false);
   const [isLoading, setIsLoading] = useState(false);

--- a/src/pages/Control.jsx
+++ b/src/pages/Control.jsx
@@ -44,7 +44,12 @@ export default function Control() {
       `${config.backendUrl}/projects/${id}/controls/${nextPageId}/`,
       JSON.stringify(postVariables),
       (response) => {
-        toast(AlertToast("success", `Control ${controlId} has been saved.`));
+        toast(
+          AlertToast(
+            "success",
+            `Control ${controlId.toUpperCase()} has been saved.`
+          )
+        );
         const nextLink = `/projects/${id}/controls/${nextPageId}`;
         navigate(nextLink);
       },

--- a/src/pages/Control.test.jsx
+++ b/src/pages/Control.test.jsx
@@ -31,12 +31,12 @@ const projectData = {
       inherited: {
         OCISO: {
           description: "This is a hybrid control.",
-          responsibility: ["Hybrid"],
+          responsibility: "Hybrid",
           provider: "Yes",
         },
         AWS: {
           description: "CMS Cloud is responsible",
-          responsibility: ["Hybrid"],
+          responsibility: "Hybrid",
           provider: "Yes",
         },
       },

--- a/src/pages/Control.test.jsx
+++ b/src/pages/Control.test.jsx
@@ -16,8 +16,8 @@ const projectData = {
     label: "AC-01",
     title: "Access Control Policy and Procedures",
     family: "Access Control",
-    description: "",
-    implementation: "",
+    description: "This is the coolest control.",
+    implementation: "We used the thing.",
     guidance: "Do the thing right.",
     version: "CMS_ARS_3_1_catalog",
     next_id: "zz-99",
@@ -77,7 +77,7 @@ afterAll(() => {
   jest.restoreAllMocks();
 });
 
-test("renders the LoadingIcon when waiting for data, then renders the pageTemplate when project data is successfully returned", async () => {
+test("renders the LoadingIcon when waiting for data, then renders the pageTemplate when data is successfully returned", async () => {
   const controlId = "ac-1";
   const projectId = projectData.project.id;
   const getResponse = { status: 200, data: projectData };
@@ -102,14 +102,9 @@ test("renders the LoadingIcon when waiting for data, then renders the pageTempla
 
   const expectedTitle = `${projectData.project.title} (${projectData.project.acronym})`;
   await waitFor(() => {
-    // ensures component has finished running async code and has rendered data
+    // displays data
     screen.getByText(expectedTitle);
   });
-
-  // checks that project template has rendered
-  expect(screen.getByTestId("project_header_subtitle")).toHaveTextContent(
-    "System Control: AC-01 Access Control Policy and Procedures"
-  );
 });
 
 test("renders the ErrorMessage when projects data is NOT successfully returned", async () => {
@@ -151,6 +146,88 @@ test("renders the ErrorMessage when projects data is NOT successfully returned",
   expect(within(errorMessage).getByRole("heading")).toHaveTextContent("Error");
 });
 
+test("displays page data as expected", async () => {
+  const dataToRender = {
+    project: {
+      id: 21,
+      title: "Name Full Test",
+      acronym: "NFT",
+    },
+    catalog_data: {
+      label: "AC-01",
+      title: "Access Control Policy and Procedures",
+      family: "Access Control",
+      description: "This is the coolest control",
+      implementation: "the thing is done",
+      guidance: "Do the thing right.",
+      version: "CMS_ARS_3_1_catalog",
+      next_id: "zz-99",
+    },
+    component_data: {
+      responsibility: "Hybrid",
+      components: {
+        inherited: {
+          OCISO: {
+            description: "This is a hybrid control.",
+            responsibility: "Hybrid",
+            provider: "Yes",
+          },
+        },
+        private: {},
+      },
+    },
+  };
+  const controlId = "ac-1";
+  const projectId = dataToRender.project.id;
+  const getResponse = { status: 200, data: dataToRender };
+  axios.get.mockImplementation(() => Promise.resolve(getResponse));
+
+  render(
+    <MemoryRouter
+      initialEntries={[`/projects/${projectId}/controls/${controlId}`]}
+    >
+      <GlobalStateProvider>
+        <Routes>
+          <Route
+            path="projects/:id/controls/:controlId"
+            element={<Control />}
+          />
+        </Routes>
+      </GlobalStateProvider>
+    </MemoryRouter>
+  );
+
+  const expectedTitle = `${dataToRender.project.title} (${dataToRender.project.acronym})`;
+  await waitFor(() => {
+    // ensures component has finished running async code and has rendered data
+    screen.getByText(expectedTitle);
+  });
+
+  const expectedSubtitle = `System Control: ${dataToRender.catalog_data.label} ${dataToRender.catalog_data.title}`;
+  expect(screen.getByTestId("project_header_subtitle")).toHaveTextContent(
+    expectedSubtitle
+  );
+
+  screen.getByText(dataToRender.catalog_data.version);
+  screen.getByText(dataToRender.catalog_data.family);
+  screen.getByText(dataToRender.catalog_data.description);
+  screen.getByText(dataToRender.catalog_data.description);
+  screen.getByText(dataToRender.catalog_data.implementation);
+  screen.getByText(dataToRender.catalog_data.guidance);
+
+  const responsibilityBox = screen.getByTestId("responsibility_box");
+  expect(responsibilityBox).toHaveTextContent(
+    dataToRender.component_data.responsibility
+  );
+
+  const inheritedComponents = screen.getByTestId(
+    "accordionItem_inherited_narratives"
+  );
+  expect(inheritedComponents).toHaveTextContent(
+    dataToRender.component_data.components.inherited.OCISO.description
+  );
+});
+
 test("save and next button makes patch call and directs user to next control page", async () => {
   const controlId = "ac-1";
   const nextControlId = projectData.catalog_data.next_id;
@@ -170,7 +247,6 @@ test("save and next button makes patch call and directs user to next control pag
   render(
     <MemoryRouter
       initialEntries={[`/projects/${projectId}/controls/${controlId}`]}
-      initialIndex={0}
     >
       <GlobalStateProvider>
         <Routes>

--- a/src/pages/Control.test.jsx
+++ b/src/pages/Control.test.jsx
@@ -10,9 +10,11 @@ import { config } from "../config";
 import { GlobalStateProvider } from "../GlobalState";
 
 const projectData = {
-  id: 21,
-  title: "Name Full Test",
-  acronym: "NFT",
+  project: {
+    id: 21,
+    title: "Name Full Test",
+    acronym: "NFT",
+  },
   catalog_data: {
     label: "AC-01",
     title: "Access Control Policy and Procedures",
@@ -46,15 +48,14 @@ const projectData = {
 test("renders the LoadingIcon when waiting for data, then renders the pageTemplate when project data is successfully returned", async () => {
   let mock = new MockAdapter(axios);
   const controlId = "ac-1";
+  const projectId = projectData.project.id;
   mock
-    .onGet(
-      `${config.backendUrl}/projects/${projectData.id}/controls/${controlId}/`
-    )
+    .onGet(`${config.backendUrl}/projects/${projectId}/controls/${controlId}/`)
     .reply(200, projectData);
 
   render(
     <MemoryRouter
-      initialEntries={[`/projects/${projectData.id}/controls/${controlId}`]}
+      initialEntries={[`/projects/${projectId}/controls/${controlId}`]}
     >
       <GlobalStateProvider>
         <Routes>
@@ -67,15 +68,15 @@ test("renders the LoadingIcon when waiting for data, then renders the pageTempla
     </MemoryRouter>
   );
   screen.getByTestId("loading_indicator");
-  const expectedTitle = `${projectData.title} (${projectData.acronym})`;
+  const expectedTitle = `${projectData.project.title} (${projectData.project.acronym})`;
   await waitFor(() => {
     // ensures component has finished running async code and has rendered data
     screen.getByText(expectedTitle);
-    // checks that project template has rendered
-    expect(screen.getByTestId("project_header_subtitle")).toHaveTextContent(
-      "System Control: AC-01 Access Control Policy and Procedures"
-    );
   });
+  // checks that project template has rendered
+  expect(screen.getByTestId("project_header_subtitle")).toHaveTextContent(
+    "System Control: AC-01 Access Control Policy and Procedures"
+  );
 });
 
 test("renders the ErrorMessage when projects data is NOT successfully returned", async () => {
@@ -119,20 +120,17 @@ test("renders the ErrorMessage when projects data is NOT successfully returned",
 test("renders the the page and marks control as completed and clicks next", async () => {
   let mock = new MockAdapter(axios);
   const controlId = "ac-1";
+  const projectId = projectData.project.id;
   mock
-    .onGet(
-      `${config.backendUrl}/projects/${projectData.id}/controls/${controlId}/`
-    )
+    .onGet(`${config.backendUrl}/projects/${projectId}/controls/${controlId}/`)
     .reply(200, projectData);
   mock
-    .onPost(
-      `${config.backendUrl}/projects/${projectData.id}/controls/${controlId}/`
-    )
+    .onPost(`${config.backendUrl}/projects/${projectId}/controls/${controlId}/`)
     .reply(200, projectData);
 
   render(
     <MemoryRouter
-      initialEntries={[`/projects/${projectData.id}/controls/${controlId}`]}
+      initialEntries={[`/projects/${projectId}/controls/${controlId}`]}
     >
       <GlobalStateProvider>
         <Routes>
@@ -144,12 +142,12 @@ test("renders the the page and marks control as completed and clicks next", asyn
       </GlobalStateProvider>
     </MemoryRouter>
   );
-  const expectedTitle = `${projectData.title} (${projectData.acronym})`;
+  const expectedTitle = `${projectData.project.title} (${projectData.project.acronym})`;
   await waitFor(() => {
     screen.getByText(expectedTitle);
   });
 
   const checkbox = screen.getByLabelText("Mark as complete");
   fireEvent.click(checkbox);
-  fireEvent.click(screen.getByRole("button", { name: "Save & next" }));
+  // await fireEvent.click(screen.getByRole("button", { name: "Save & next" }));
 });

--- a/src/pages/Controls.jsx
+++ b/src/pages/Controls.jsx
@@ -17,8 +17,8 @@ const ProjectControls = () => {
 
   const [state, setState] = useContext(GlobalState);
   const [controls, setControls] = useState(false);
-  const [isLoadingProject, setIsLoadingProject] = useState(true);
-  const [isLoadingControls, setIsLoadingControls] = useState(true);
+  const [isLoadingProject, setIsLoadingProject] = useState(false);
+  const [isLoadingControls, setIsLoadingControls] = useState(false);
   const urlParams = useLocation();
   const getParams = urlParams.search;
 

--- a/src/pages/Controls.jsx
+++ b/src/pages/Controls.jsx
@@ -36,7 +36,7 @@ const ProjectControls = () => {
         }
       );
     }
-  }, []);
+  }, [id, setState, state.project]);
 
   useEffect(() => {
     setIsLoadingControls(true);
@@ -50,7 +50,7 @@ const ProjectControls = () => {
         setIsLoadingControls(false);
       }
     );
-  }, []);
+  }, [id, getParams]);
 
   if (isLoadingControls || isLoadingProject) {
     return <LoadingIndicator />;

--- a/src/services/RequestService.js
+++ b/src/services/RequestService.js
@@ -66,6 +66,19 @@ const RequestService = {
         failureCallback && failureCallback(err);
       });
   },
+  patch: async (url, body, callback, failureCallback) => {
+    let postConfig = authConfig;
+
+    axios
+      .patch(url, body, postConfig)
+      .then((response) => {
+        callback && callback(response);
+      })
+      .catch((err) => {
+        err.response.status === 401 && handleExpiredToken();
+        failureCallback && failureCallback(err);
+      });
+  },
   delete: async (url, callback, failureCallback) => {
     axios
       .delete(url, authConfig)

--- a/src/services/RequestService.test.js
+++ b/src/services/RequestService.test.js
@@ -67,6 +67,30 @@ describe("<RequestService />", () => {
     });
   });
 
+  it("patches", (done) => {
+    mock.onPatch("fake.url").reply(200, data);
+    RequestService.patch("fake.url", {}, (response) => {
+      try {
+        expect(response.status).toBe(200);
+        expect(response.data).toStrictEqual(data);
+        done();
+      } catch (error) {
+        done(error);
+      }
+    });
+  });
+  it("patches and fails", (done) => {
+    mock.onPatch("fake.url").reply(500, data);
+    RequestService.patch("fake.url", {}, null, (err) => {
+      try {
+        expect(err.response.status).toBe(500);
+        done();
+      } catch (error) {
+        done(error);
+      }
+    });
+  });
+
   it("deletes", (done) => {
     mock.onDelete("fake.url").reply(200, data);
     RequestService.delete("fake.url", (response) => {

--- a/src/templates/ComponentTemplate.jsx
+++ b/src/templates/ComponentTemplate.jsx
@@ -149,7 +149,8 @@ ComponentTemplate.propTypes = {
     family: PropTypes.string,
     guidance: PropTypes.string,
     implementationStandards: PropTypes.string,
-    responsibility: PropTypes.oneOf(["none", "some", "all"]).isRequired,
+    responsibility: PropTypes.oneOf(["Inherited", "Hybrid", "Allocated"])
+      .isRequired,
     version: PropTypes.string,
   }),
   handleProjectUpdate: PropTypes.func,

--- a/src/templates/ComponentTemplate.jsx
+++ b/src/templates/ComponentTemplate.jsx
@@ -7,7 +7,7 @@ import ControlHeader from "../organisms/ControlHeader";
 
 export function ComponentTemplate({
   component,
-  controlText,
+  selectedControl,
   catalogData,
   handleProjectUpdate,
 }) {
@@ -16,21 +16,31 @@ export function ComponentTemplate({
   const accordionItemsProps = [
     {
       title: "CMS Implementation Standards",
-      content: <p>{controlText.implementationStandards}</p>,
+      content: (
+        <p>
+          {selectedControl.implementationStandards ||
+            "No implementation standards found for this control."}
+        </p>
+      ),
       expanded: false,
       id: "implementation_standards",
       headingLevel: "h3",
     },
     {
       title: "CMS Control Guidance",
-      content: <p>{controlText.guidance}</p>,
+      content: (
+        <p>
+          {selectedControl.guidance ||
+            "No control guidance found for this control."}
+        </p>
+      ),
       expanded: false,
       id: "control_guidance",
       headingLevel: "h3",
     },
     {
       title: "Narrative",
-      content: <p>{controlText.narrative}</p>,
+      content: <p>{selectedControl.narrative}</p>,
       expanded: true,
       id: "inherited_narratives",
       headingLevel: "h3",
@@ -91,11 +101,11 @@ export function ComponentTemplate({
             </nav>
           </div>
           <div className="grid-col-fill padding-4 margin-x-2">
-            {controlText ? (
+            {selectedControl ? (
               <>
-                <ControlHeader control={controlText} />
+                <ControlHeader control={selectedControl} />
                 <ResponsibilityBox
-                  responsibility={controlText.responsibility}
+                  responsibilityForControl={selectedControl.responsibility}
                 />
                 <div className="control-page">
                   <Accordion
@@ -131,26 +141,36 @@ export function ComponentTemplate({
 }
 
 ComponentTemplate.propTypes = {
+  catalogData: PropTypes.func,
   component: PropTypes.shape({
+    component_data: PropTypes.shape({
+      title: PropTypes.string,
+      description: PropTypes.string,
+      standard: PropTypes.string,
+      source: PropTypes.string,
+    }),
+    project_data: PropTypes.object,
+    catalog_data: PropTypes.shape({
+      controls: PropTypes.object,
+    }),
     id: PropTypes.number,
-    title: PropTypes.string,
-    description: PropTypes.string,
-    standard: PropTypes.string,
-    source: PropTypes.string,
-    narrative: PropTypes.string,
-    responsibility: PropTypes.string,
-    controls: PropTypes.array,
-  }).isRequired,
-  control: PropTypes.shape({
+    assessment: PropTypes.string,
+    vetted: PropTypes.string,
+  }),
+  selectedControl: PropTypes.shape({
     controlId: PropTypes.string,
     controlTitle: PropTypes.string,
     controlFamily: PropTypes.string,
     description: PropTypes.string,
-    family: PropTypes.string,
     guidance: PropTypes.string,
     implementationStandards: PropTypes.string,
-    responsibility: PropTypes.oneOf(["Inherited", "Hybrid", "Allocated"])
-      .isRequired,
+    narrative: PropTypes.string,
+    responsibilityForControl: PropTypes.oneOf([
+      "Inherited",
+      "Hybrid",
+      "Allocated",
+      null,
+    ]),
     version: PropTypes.string,
   }),
   handleProjectUpdate: PropTypes.func,

--- a/src/templates/ControlTemplate.jsx
+++ b/src/templates/ControlTemplate.jsx
@@ -35,7 +35,6 @@ export default function ControlTemplate({
     guidance,
     implementation,
     version,
-    next_id: nextControlLabel,
   } = control;
   const { responsibility, components } = componentData;
   const subtitle = `System Control: ${label.toUpperCase()} ${controlTitle}`;

--- a/src/templates/ControlTemplate.jsx
+++ b/src/templates/ControlTemplate.jsx
@@ -32,8 +32,8 @@ export default function ControlTemplate({
     title: controlTitle,
     description,
     family,
-    guidance = "No control guidance found for this control",
-    implementation = "No implementation standards found for this control",
+    guidance,
+    implementation,
     version,
     next_id: nextControlLabel,
   } = control;
@@ -43,14 +43,21 @@ export default function ControlTemplate({
   let accordionItemsProps = [
     {
       title: "CMS Implementation Standards",
-      content: <p>{implementation}</p>,
+      content: (
+        <p>
+          {implementation ||
+            "No implementation standards found for this control."}
+        </p>
+      ),
       expanded: false,
       id: "implementation_standards",
       headingLevel: "h3",
     },
     {
       title: "CMS Control Guidance",
-      content: <p>{guidance}</p>,
+      content: (
+        <p>{guidance || "No control guidance found for this control."}</p>
+      ),
       expanded: false,
       id: "control_guidance",
       headingLevel: "h3",

--- a/src/templates/ControlTemplate.jsx
+++ b/src/templates/ControlTemplate.jsx
@@ -118,7 +118,7 @@ export default function ControlTemplate({
       <p className="control-description" data-testid="control_description">
         <b>Control Description:</b> {description}
       </p>
-      <ResponsibilityBox responsibility={responsibility} />
+      <ResponsibilityBox responsibilityForControl={responsibility} />
       <Accordion
         items={accordionItemsProps}
         multiselectable
@@ -153,8 +153,12 @@ ControlTemplate.propTypes = {
   }).isRequired,
   componentData: PropTypes.shape({
     components: PropTypes.object,
-    responsibility: PropTypes.oneOf(["Inherited", "Hybrid", "Allocated"])
-      .isRequired,
+    responsibilityForControl: PropTypes.oneOf([
+      "Inherited",
+      "Hybrid",
+      "Allocated",
+      null,
+    ]),
   }),
   submitCallback: PropTypes.func,
 };

--- a/src/templates/ControlTemplate.jsx
+++ b/src/templates/ControlTemplate.jsx
@@ -157,4 +157,5 @@ ControlTemplate.propTypes = {
     responsibility: PropTypes.oneOf(["Inherited", "Hybrid", "Allocated"])
       .isRequired,
   }),
+  submitCallback: PropTypes.func,
 };

--- a/src/templates/ControlTemplate.test.jsx
+++ b/src/templates/ControlTemplate.test.jsx
@@ -28,7 +28,7 @@ const componentData = {
         description:
           "CMS Cloud provides a check in the Inspec profile to ensure that systems are configured to display the approved CMS system notification.",
         provider: "Yes",
-        responsibility: ["Inherited"],
+        responsibility: "Inherited",
       },
     },
     private: {},


### PR DESCRIPTION
_This PR contains fixes and cleanup as a continuation of https://github.com/CMSgov/blueprint_ui/pull/63_

*What does this PR do?*
Sets up the control page to use data from the api.

*Jira ticket number?*
[ISPGBSS-1179](https://jiraent.cms.gov/browse/ISPGBSS-1179)

*Changes*

- Control page:
  - Refactored `Control.jsx` to clean up a lot of unneeded code
  - Removed `if` statement in `useEffect` that was checking for project data in Context. Because this project data was incomplete (it didn't have all the extra control related data that this page needs), the api call **wasn't** executed so the page was attempting to render with missing data and was subsequently erroring out.
  - Fixed save and next button so it can correctly navigate to the next page
  - Added alert toasts to the control page for save & next button
  - Fixed typo in class name that was preventing styling from being applied to the bottom of the control page
- Added a `patch` call to the RequestService and updated save and next button on Control page to use it
- Finished converting the responsibility types throughout the rest of the application (a previous merge had started this but it was incomplete)
- Set up responsibility box to have a default of "Allocated" (since this can, and currently is, happening)
- Updated `PropTypes` for `Component.jsx` to reflect the current prop usage
- Fixed issue on Controls list page where the page would get stuck on the "Loading" screen
- Added testing

