### PR TITLE
Fixing the background color on striped tables

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -367,6 +367,10 @@ nav.usa-breadcrumb {
   background-color: white;
 }
 
+.usa-table--striped .usa-checkbox {
+  background: none;
+}
+
 .usa-checkbox__input--tile + [class*="__label"],
 .usa-radio__input--tile + [class*="__label"] {
   background: #f0f0f0;


### PR DESCRIPTION
*What does this PR do?*

Currently, any of our tables that are striped and have checkboxes look terrible.  This makes it look less terrible as a bandaid.

*Changes*

- Removing background color for uswds checkboxes when they are in tables

*Testing*

- [ ] Step 1: Look at the 'select your components' page of the new project flow
- [ ] Step 2: The gray background of the table should wrap the checkboxes correctly
