### PR TITLE
Formatting catalog titles to be human friendly

### DIFF
--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -35,3 +35,25 @@ export const getControlData = (component = {}, controlId) => {
 
   return controlData;
 };
+
+export const formatCatalogTitle = (catalogTitle) => {
+  let titleArray = catalogTitle.split("_");
+  if (titleArray.length == 5) {
+    let formattedImpactLevel =
+      titleArray[4][0].toUpperCase() + titleArray[4].substring(1).toLowerCase();
+    return (
+      titleArray[0] +
+      " " +
+      titleArray[1] +
+      " " +
+      titleArray[2] +
+      "." +
+      titleArray[3] +
+      " (" +
+      formattedImpactLevel +
+      ")"
+    );
+  } else {
+    return catalogTitle;
+  }
+};

--- a/src/Helpers.test.js
+++ b/src/Helpers.test.js
@@ -1,0 +1,15 @@
+import { formatCatalogTitle } from "./Helpers";
+
+describe("Catalog helper methods", () => {
+  it("formatCatalogTitle formats proper catalog titles", () => {
+    let rawCatalogTitle = "CMS_ARS_3_1_HIGH";
+    let formattedTitle = formatCatalogTitle(rawCatalogTitle);
+    expect(formattedTitle).toEqual("CMS ARS 3.1 (High)");
+  });
+
+  it("formatCatalogTitle does not format irregular catalog titles", () => {
+    let rawCatalogTitle = "CMS_ARS_3_1";
+    let formattedTitle = formatCatalogTitle(rawCatalogTitle);
+    expect(formattedTitle).toEqual("CMS_ARS_3_1");
+  });
+});

--- a/src/templates/SearchLibrary.jsx
+++ b/src/templates/SearchLibrary.jsx
@@ -10,6 +10,7 @@ import {
 import { Link } from "react-router-dom";
 import { MAIN_ROUTES } from "../AppRoutes";
 import Pagination from "../molecules/Pagination";
+import { formatCatalogTitle } from "../Helpers";
 
 const TableRow = ({ component }) => {
   if (component.title === undefined) {
@@ -86,7 +87,7 @@ const FilterCol = ({
               <Checkbox
                 id={catalog.id + "-filter"}
                 name={catalog.name + "-filter"}
-                label={catalog.name}
+                label={formatCatalogTitle(catalog.name)}
                 value={"catalog=" + catalog.id}
                 onChange={checkBoxHandler}
                 key={i}


### PR DESCRIPTION
*What does this PR do?*
Adds helper method to format catalog titles.

*Jira ticket number?*
n/a

*Changes*

- Adds catalog title formatter
- Uses title formatter in the SearchLibraryComponent

*Testing*

- [ ] Step 1 - Go to Component Library
- [ ] Step 2 - Catalog titles should be human readable
