### PR TITLE
Feature/not applicable 1236

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -14,6 +14,8 @@ $gray-dark: #979797;
 $gray-darker: #71767a;
 $gray-darkest: #343434;
 
+$red-button: #8b1303;
+
 // Breakpoints for screen sizes
 $tablet-size-max-width: 640px;
 $card-collection-two-per-row-width: 900px;

--- a/src/App.scss
+++ b/src/App.scss
@@ -626,3 +626,48 @@ nav.usa-breadcrumb {
   transform: translateX(0) translateY(-50%);
   border-left-color: $blue-primary;
 }
+
+/* Toggle switch */
+.toggle-checkbox {
+  height: 0;
+  width: 0;
+  visibility: hidden;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  width: 30px;
+  height: 17px;
+  background: $green-button;
+  border-radius: 100px;
+  position: relative;
+  transition: background-color 0.2s;
+
+  .toggle-button {
+    content: "";
+    position: absolute;
+    top: 1px;
+    left: 3px;
+    width: 15px;
+    height: 15px;
+    border-radius: 15px;
+    transition: 0.2s;
+    background: #fff;
+    box-shadow: 0 0 2px 0 rgba(10, 10, 10, 0.29);
+  }
+}
+
+.toggle-label:active .toggle-button {
+  width: 30px;
+}
+
+.toggle-checkbox:checked + .toggle-label {
+  background: $red-button;
+  .toggle-button {
+    left: calc(100% - 2px);
+    transform: translateX(-100%);
+  }
+}

--- a/src/atoms/BlueprintModal.jsx
+++ b/src/atoms/BlueprintModal.jsx
@@ -1,9 +1,9 @@
 import {
+  Button,
   ButtonGroup,
   Modal,
   ModalFooter,
   ModalHeading,
-  ModalToggleButton,
 } from "@trussworks/react-uswds";
 import { forwardRef } from "react";
 
@@ -21,16 +21,15 @@ const BlueprintModal = forwardRef((props, modalRef) => {
       </div>
       <ModalFooter>
         <ButtonGroup>
-          <ModalToggleButton
-            modalRef={modalRef}
-            closer
+          <Button
             className="padding-105 text-center"
+            onClick={() => props.clickHandler(true)}
           >
             {props.button}
-          </ModalToggleButton>
-          <ModalToggleButton modalRef={modalRef} unstyled closer>
+          </Button>
+          <Button unstyled onClick={() => props.clickHandler(false)}>
             {props.link}
-          </ModalToggleButton>
+          </Button>
         </ButtonGroup>
       </ModalFooter>
     </Modal>

--- a/src/atoms/BlueprintModal.jsx
+++ b/src/atoms/BlueprintModal.jsx
@@ -1,0 +1,40 @@
+import {
+  ButtonGroup,
+  Modal,
+  ModalFooter,
+  ModalHeading,
+  ModalToggleButton,
+} from "@trussworks/react-uswds";
+import { forwardRef } from "react";
+
+const BlueprintModal = forwardRef((props, modalRef) => {
+  return (
+    <Modal
+      ref={modalRef}
+      id={props.id + "-modal"}
+      aria-labelledby={props.id + "-heading"}
+      aria-describedby={props.id + "-description"}
+    >
+      <ModalHeading id={props.id + "-heading"}>{props.header}</ModalHeading>
+      <div className="usa-prose">
+        <p id={props.id + "-description"}>{props.body}</p>
+      </div>
+      <ModalFooter>
+        <ButtonGroup>
+          <ModalToggleButton
+            modalRef={modalRef}
+            closer
+            className="padding-105 text-center"
+          >
+            {props.button}
+          </ModalToggleButton>
+          <ModalToggleButton modalRef={modalRef} unstyled closer>
+            {props.link}
+          </ModalToggleButton>
+        </ButtonGroup>
+      </ModalFooter>
+    </Modal>
+  );
+});
+
+export default BlueprintModal;

--- a/src/atoms/Toggle.jsx
+++ b/src/atoms/Toggle.jsx
@@ -9,6 +9,7 @@ const Toggle = ({ isOn, onChange }) => {
         type="checkbox"
         checked={isOn}
         onChange={onChange}
+        data-testid={"on-off-toggle"}
       />
       <label className="toggle-label" htmlFor={`toggle-switch`}>
         <span className={`toggle-button`} />

--- a/src/atoms/Toggle.jsx
+++ b/src/atoms/Toggle.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+const Toggle = ({ isOn, onChange }) => {
+  return (
+    <>
+      <input
+        className="toggle-checkbox"
+        id={`toggle-switch`}
+        type="checkbox"
+        checked={isOn}
+        onChange={onChange}
+      />
+      <label className="toggle-label" htmlFor={`toggle-switch`}>
+        <span className={`toggle-button`} />
+      </label>
+    </>
+  );
+};
+
+export default Toggle;

--- a/src/pages/Control.jsx
+++ b/src/pages/Control.jsx
@@ -105,6 +105,7 @@ export default function Control() {
     controlData.id = pageData.control.id;
     controlData.controlIdName = pageData.control.control_id;
     controlData.status = pageData.status;
+    controlData.remarks = pageData.remarks ? pageData.remarks : null;
     return (
       <ControlTemplate
         project={pageData.project}

--- a/src/templates/ControlTemplate.jsx
+++ b/src/templates/ControlTemplate.jsx
@@ -41,7 +41,7 @@ export default function ControlTemplate({
     "Add a text field to tell us how your system is addressing this control";
 
   let naTooltipContent =
-    "Non-applicable controls will not be include in your System Security Plan";
+    "Non-applicable controls will not be included in your System Security Plan";
 
   let accordionItemsProps = [
     {
@@ -217,7 +217,7 @@ export default function ControlTemplate({
             </>
           )}
           <div className="tooltip-div margin-left-1">
-            <Tooltip content={naTooltipContent} direction="right">
+            <Tooltip content={naTooltipContent} direction="down">
               <img type="button" src={moreInfo} alt="More info." />
             </Tooltip>
           </div>

--- a/src/templates/ControlTemplate.jsx
+++ b/src/templates/ControlTemplate.jsx
@@ -48,6 +48,52 @@ export default function ControlTemplate({
   const handleDeselectNaOpen = () =>
     deselectNaModalRef.current?.toggleModal(undefined, true);
 
+  function handleDeselectModalClicks(e) {
+    if (e) {
+      deselectNaModalRef.current?.toggleModal(undefined, false);
+      document
+        .querySelector(".usa-accordion__content")
+        .setAttribute("hidden", "hidden");
+      document
+        .querySelector(".usa-accordion__button")
+        .removeAttribute("aria-expanded");
+      document
+        .querySelector(".usa-accordion__content")
+        .setAttribute("aria-hidden", "hidden");
+    } else {
+      deselectNaModalRef.current?.toggleModal(undefined, false);
+      setNotApplicable(true);
+    }
+  }
+
+  function handleSelectModalClicks(e) {
+    if (e) {
+      selectNaModalRef.current?.toggleModal(undefined, false);
+      document.querySelector("#remarks").removeAttribute("hidden");
+      document
+        .querySelector("#remarks")
+        .setAttribute("aria-expanded", "expanded");
+      document.querySelector("#remarks").removeAttribute("aria-hidden");
+    } else {
+      selectNaModalRef.current?.toggleModal(undefined, false);
+      setNotApplicable(false);
+    }
+  }
+
+  function handleEmptyRemarksModalClicks(e) {
+    if (e) {
+      naErrorModalRef.current?.toggleModal(undefined, false);
+      document.querySelector("#remarks").removeAttribute("hidden");
+      document
+        .querySelector("#remarks")
+        .setAttribute("aria-expanded", "expanded");
+      document.querySelector("#remarks").removeAttribute("aria-hidden");
+    } else {
+      naErrorModalRef.current?.toggleModal(undefined, false);
+      setNotApplicable(false);
+    }
+  }
+
   let tooltipContent =
     "Add a text field to tell us how your system is addressing this control";
 
@@ -148,6 +194,7 @@ export default function ControlTemplate({
 
   function onClickNext() {
     let patchComponentVariables;
+    let sendIt = true;
     if (showPrivateNarrativeBox) {
       patchComponentVariables = createPatchComponentVariables();
     }
@@ -163,13 +210,16 @@ export default function ControlTemplate({
     if (notApplicable) {
       let remarks = document.getElementById("textarea-na-remarks").value;
       if (!remarks) {
+        sendIt = false;
         handleNaErrorOpen();
       } else {
         patchControlVariables["remarks"] = remarks;
       }
     }
 
-    submitCallback(patchComponentVariables, patchControlVariables);
+    if (sendIt) {
+      submitCallback(patchComponentVariables, patchControlVariables);
+    }
   }
 
   function renderInheritedComponentNarratives() {
@@ -300,7 +350,7 @@ export default function ControlTemplate({
           label="Mark as complete"
           defaultChecked={status === "complete"}
         />
-        <button className="usa-button" onClick={onClickNext}>
+        <button className="usa-button" onClick={(e) => onClickNext(e)}>
           Save & next
         </button>
       </div>
@@ -310,6 +360,7 @@ export default function ControlTemplate({
         header={"Non-applicable controls must have documented justifications."}
         button={"Go back"}
         link={"Continue without saving"}
+        clickHandler={handleEmptyRemarksModalClicks}
       />
       <BlueprintModal
         id={"select-na"}
@@ -320,6 +371,7 @@ export default function ControlTemplate({
         }
         button={"Disable"}
         link={"Go back"}
+        clickHandler={handleSelectModalClicks}
       />
       <BlueprintModal
         id={"deselect-na"}
@@ -330,6 +382,7 @@ export default function ControlTemplate({
         }
         button={"Enable"}
         link={"Go back"}
+        clickHandler={handleDeselectModalClicks}
       />
     </div>
   );

--- a/src/templates/ControlTemplate.jsx
+++ b/src/templates/ControlTemplate.jsx
@@ -1,6 +1,7 @@
 import { Accordion, Checkbox, Textarea } from "@trussworks/react-uswds";
 import PropTypes from "prop-types";
-import { useEffect, useState } from "react";
+import { createRef, useEffect, useState } from "react";
+import BlueprintModal from "../atoms/BlueprintModal";
 import ResponsibilityBox from "../atoms/ResponsibilityBox";
 import Toggle from "../atoms/Toggle";
 import Tooltip from "../atoms/Tooltip";
@@ -36,6 +37,16 @@ export default function ControlTemplate({
   const { responsibility, components } = component;
   const subtitle = `System Control: ${label} ${controlTitle}`;
   const existingPrivateNarrative = components.private.description || "";
+
+  const naErrorModalRef = createRef();
+  const handleNaErrorOpen = () =>
+    naErrorModalRef.current?.toggleModal(undefined, true);
+  const selectNaModalRef = createRef();
+  const handleSelectNaOpen = () =>
+    selectNaModalRef.current?.toggleModal(undefined, true);
+  const deselectNaModalRef = createRef();
+  const handleDeselectNaOpen = () =>
+    deselectNaModalRef.current?.toggleModal(undefined, true);
 
   let tooltipContent =
     "Add a text field to tell us how your system is addressing this control";
@@ -82,6 +93,7 @@ export default function ControlTemplate({
           id="textarea-private-narrative"
           placeholder="Add your private control narrative here."
           className={"control-page-textarea"}
+          name={"private-narrative"}
           defaultValue={existingPrivateNarrative}
         />
       ),
@@ -151,8 +163,7 @@ export default function ControlTemplate({
     if (notApplicable) {
       let remarks = document.getElementById("textarea-na-remarks").value;
       if (!remarks) {
-        // Trigger modal here.
-        alert("Status is na and no remark");
+        handleNaErrorOpen();
       } else {
         patchControlVariables["remarks"] = remarks;
       }
@@ -182,6 +193,11 @@ export default function ControlTemplate({
 
   function onChangeNA(e) {
     let is_na = e.target.checked;
+    if (is_na) {
+      handleSelectNaOpen();
+    } else {
+      handleDeselectNaOpen();
+    }
     setNotApplicable(is_na);
   }
 
@@ -235,7 +251,7 @@ export default function ControlTemplate({
                   placeholder="Describe why this control is not applicable to your system project."
                   className={"control-page-textarea"}
                   name={"remarks"}
-                  value={remarks}
+                  defaultValue={remarks}
                 />
               ),
               expanded: true,
@@ -280,6 +296,7 @@ export default function ControlTemplate({
       <div className="bottom-section">
         <Checkbox
           id="is-complete-checkbox"
+          name={"is-complete"}
           label="Mark as complete"
           defaultChecked={status === "complete"}
         />
@@ -287,6 +304,33 @@ export default function ControlTemplate({
           Save & next
         </button>
       </div>
+      <BlueprintModal
+        id={"na-error"}
+        ref={naErrorModalRef}
+        header={"Non-applicable controls must have documented justifications."}
+        button={"Go back"}
+        link={"Continue without saving"}
+      />
+      <BlueprintModal
+        id={"select-na"}
+        ref={selectNaModalRef}
+        header={"Are you sure you want to disable this narrative?"}
+        body={
+          "This will remove it from your System Security Plan. You can choose to enable it later if needed. This could affect the inheritance state of this control."
+        }
+        button={"Disable"}
+        link={"Go back"}
+      />
+      <BlueprintModal
+        id={"deselect-na"}
+        ref={deselectNaModalRef}
+        header={"Are you sure you want to enable this narrative?"}
+        body={
+          "This will add it back into your System Security Plan. You can choose to disable it later if needed. This could affect the inheritance state of this control."
+        }
+        button={"Enable"}
+        link={"Go back"}
+      />
     </div>
   );
 }

--- a/src/templates/ControlTemplate.test.jsx
+++ b/src/templates/ControlTemplate.test.jsx
@@ -107,3 +107,23 @@ test("renders each section on the page", () => {
     expectedSubtitle
   );
 });
+
+test("clicking not applicable shows remarks", () => {
+  render(
+    <MemoryRouter>
+      <ControlTemplate
+        project={projectData}
+        control={controlData}
+        component={componentData}
+      />
+    </MemoryRouter>
+  );
+
+  const accordionSections = screen.getAllByTestId("accordion");
+  fireEvent.click(screen.getByTestId("on-off-toggle"));
+  const topAccordionItems = accordionSections[0];
+  const natApplicableAccordion = within(topAccordionItems).getByText(
+    "Non-applicable control justification"
+  );
+  expect(natApplicableAccordion).toBeInTheDocument();
+});

--- a/src/templates/ControlsList.jsx
+++ b/src/templates/ControlsList.jsx
@@ -29,6 +29,8 @@ const TableRow = ({ control }) => {
           ? "Complete"
           : control.status === "incomplete"
           ? "Incomplete"
+          : control.status === "not_applicable"
+          ? "Not applicable"
           : "Not started"}
       </td>
     </>
@@ -80,6 +82,15 @@ const FilterCol = ({ currentStatus, checkBoxHandler }) => {
             onChange={checkBoxHandler}
             key="1"
             checked={isCheckedStatus("not_started")}
+          />
+          <Checkbox
+            id="notapplicable-filter"
+            name="status__in"
+            label="Not Applicable"
+            value="not_applicable"
+            onChange={checkBoxHandler}
+            key="1"
+            checked={isCheckedStatus("not_applicable")}
           />
         </fieldset>
       </div>

--- a/src/templates/ControlsList.jsx
+++ b/src/templates/ControlsList.jsx
@@ -89,7 +89,7 @@ const FilterCol = ({ currentStatus, checkBoxHandler }) => {
             label="Not Applicable"
             value="not_applicable"
             onChange={checkBoxHandler}
-            key="1"
+            key="4"
             checked={isCheckedStatus("not_applicable")}
           />
         </fieldset>


### PR DESCRIPTION
*What does this PR do?*

*Jira ticket number?*
[ISPGBSS-1236](https://jiraent.cms.gov/browse/ISPGBSS-1236)

*Changes*

- Add not applicable toggle
- Add not applicable as a Status on Controls page
- Add remarks field for not applicable justifications
- Add modal to show when toggling on the Not Applicable toggle
- Add modal to show when toggling off the Not Applicable toggle
- Add modal to show when the NA toggle is off on and there is no Justification

*Testing*

- [ ] Go to a Control page, you should see a switch with the label **Applicable Control**
- [ ] Toggling that switch should trigger a modal to confirm that you want to set the control to Not Applicable
- [ ] In the modal, choosing _Disable_ should close the modal and the **Non-applicable control justification** accordion should be shown; all other accordions shouldn't be on the page
  - [ ] It the modal, choosing _Go back_ should take you back to the Control page with the regular accordions.
- [ ] Clicking _Save and next_ without filling out the Remarks field should trigger another modal warning that Remarks are required
- [ ] Add a Remark and click _Save and next_ and the Control should update with the status of _Not applicable_
- [ ] Go back to the _Controls_ page from the breadcrumbs
- [ ] Choose a control whose Status is _Not applicable_
- [ ] On the Control page the Not Applicable toggle should be red and the label should read **Non-applicable control**
- [ ] Toggle the switch
- [ ] You should see another modal to confirm your selection
- [ ] Confirm the selection
- [ ] You should see the regular accordions
- [ ] Toggling the Non-applicable controls switch again should show the Justification text that you added previously
